### PR TITLE
91 be change offerstatus to enum

### DIFF
--- a/prisma/migrations/20221215201817_offer_status_add_enum/migration.sql
+++ b/prisma/migrations/20221215201817_offer_status_add_enum/migration.sql
@@ -1,0 +1,22 @@
+/*
+  Warnings:
+
+  - The `status` column on the `BuyOffer` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `status` column on the `SellOffer` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+  - The `status` column on the `Transaction` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "OfferStatus" AS ENUM ('ACTIVE', 'EXPIRED', 'NO_SUFFICIENT_FUNDS', 'NO_USER_STOCK', 'OFFER_REALIZED', 'TRANSACTION_REALIZED');
+
+-- AlterTable
+ALTER TABLE "BuyOffer" DROP COLUMN "status",
+ADD COLUMN     "status" "OfferStatus" NOT NULL DEFAULT 'ACTIVE';
+
+-- AlterTable
+ALTER TABLE "SellOffer" DROP COLUMN "status",
+ADD COLUMN     "status" "OfferStatus" NOT NULL DEFAULT 'ACTIVE';
+
+-- AlterTable
+ALTER TABLE "Transaction" DROP COLUMN "status",
+ADD COLUMN     "status" "OfferStatus" NOT NULL DEFAULT 'TRANSACTION_REALIZED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,6 +7,16 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum OfferStatus {
+  ACTIVE
+  EXPIRED
+  NO_SUFFICIENT_FUNDS
+  NO_USER_STOCK
+  OFFER_REALIZED
+  TRANSACTION_REALIZED
+}
+
+
 model BuyOffer {
   buyOfferId        Int           @id @default(autoincrement())
   userId            Int
@@ -14,7 +24,7 @@ model BuyOffer {
   unitBuyPriceCents Int
   quantity          Int
   created           DateTime      @default(now()) @db.Timestamptz(6)
-  status            Int           @default(0)
+  status            OfferStatus   @default(ACTIVE)
   User              User          @relation(fields: [userId], references: [userId], onDelete: Cascade, map: "User")
   Transaction       Transaction[]
   Company           Company       @relation(fields: [companyId], references: [companyId], onDelete: Cascade, map: "BuyOffer")
@@ -36,7 +46,7 @@ model SellOffer {
   unitSellPriceCents Int
   quantity           Int
   created            DateTime      @default(now()) @db.Timestamptz(6)
-  status             Int           @default(0)
+  status             OfferStatus   @default(ACTIVE)
   User               User          @relation(fields: [userId], references: [userId], onDelete: Cascade, map: "User")
   Transaction        Transaction[]
   UserStock          UserStock     @relation(fields: [userStockId], references: [userStockId], onDelete: Cascade, map: "UserStock")
@@ -54,7 +64,7 @@ model Transaction {
   transactionId Int       @id @default(autoincrement())
   buyOfferId    Int
   sellOfferId   Int
-  status        Int       @default(0)
+  status        OfferStatus   @default(TRANSACTION_REALIZED)
   date          DateTime  @default(now()) @db.Timestamptz(6)
   sellerId      Int
   buyerId       Int

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,7 @@
 import {
   PrismaClient,
-  Prisma
+  Prisma,
+  OfferStatus
 } from '@prisma/client';
 import { faker } from '@faker-js/faker';
 import { genSalt, hash } from 'bcrypt';
@@ -14,18 +15,13 @@ async function main() {
 
   // seed params
   const amountOfUsers = 20;
-  const amountOfCompanies = 10;
+  const amountOfCompanies = 30;
   const amountOfUserStocks = 5;
-  const amountOfStockOffers = 500;
   const amountOfBuyOffers = 50;
   const amountOfSellOffers = 100;
   const amountOfHistoricalStockPricingChanges = 50;
   const maxOfferCents = 100000;
 
-  // BACK-END
-  // number of implemented status codes
-  const statusCountBuyOffer = 3;
-  const statusCountSellOffer = 3;
 
   const users: Prisma.UserCreateManyInput[] = [];
   const companies: Prisma.CompanyCreateManyInput[] = [];
@@ -103,7 +99,7 @@ async function main() {
     });
     const userBuyQuantity = faker.datatype.number({ min: 1, max: 10 });
     const userBuyOfferCreatedAt = faker.date.recent();
-    const userBuyOfferStatus = faker.datatype.number(statusCountBuyOffer);
+    const userBuyOfferStatus :OfferStatus = "ACTIVE";
 
     const buyOffer: Prisma.BuyOfferUncheckedCreateInput = {
       userId: userId,
@@ -130,7 +126,7 @@ async function main() {
     });
     const userSellQuantity = faker.datatype.number({ min: 1, max: 10 });
     const userSellOfferCreatedAt = faker.date.recent();
-    const userSellOfferStatus = faker.datatype.number(statusCountSellOffer);
+    const userSellOfferStatus :OfferStatus = "ACTIVE";
 
     const sellOffer: Prisma.SellOfferUncheckedCreateInput = {
       userId: userId,

--- a/src/backend/modules/company/company.service.ts
+++ b/src/backend/modules/company/company.service.ts
@@ -25,7 +25,7 @@ export class CompanyService {
                 unitSellPriceCents: true,
               },
               where: {
-                status: 0,
+                status: "ACTIVE",
               },
             },
           },
@@ -107,7 +107,7 @@ export class CompanyService {
                   unitSellPriceCents: true,
                 },
                 where: {
-                  status: 0,
+                  status: "ACTIVE",
                 },
               },
             },

--- a/src/backend/modules/offer/dto/create-buy-offer.dto.ts
+++ b/src/backend/modules/offer/dto/create-buy-offer.dto.ts
@@ -1,6 +1,7 @@
 import { IsNotEmpty, IsNumber, IsPositive } from 'class-validator';
 import { Exists } from '../../../decorators/exists.decorator';
 import { ApiProperty } from '@nestjs/swagger';
+import { BuyOffer, OfferStatus } from '@prisma/client';
 
 export class CreateBuyOfferDto {
   @Exists('company', 'companyId')
@@ -22,5 +23,5 @@ export class CreateBuyOfferDto {
   @IsNumber()
   @IsNotEmpty()
   @ApiProperty({type: Number, description: 'Status'})
-  status!: number;
+  status!: OfferStatus;
 }

--- a/src/backend/modules/offer/dto/create-sell-offer.dto.ts
+++ b/src/backend/modules/offer/dto/create-sell-offer.dto.ts
@@ -2,6 +2,7 @@ import { IsNotEmpty, IsNumber, IsPositive } from 'class-validator';
 
 import { Exists } from '../../../decorators/exists.decorator';
 import { ApiProperty } from '@nestjs/swagger'
+import { BuyOffer, OfferStatus } from '@prisma/client';
 
 export class CreateSellOfferDto {
   @Exists('userStock', 'userStockId')
@@ -23,5 +24,5 @@ export class CreateSellOfferDto {
   @IsNumber()
   @IsNotEmpty()
   @ApiProperty({type: Number, description: 'Status'})
-  status!: number;
+  status!: OfferStatus;
 }

--- a/src/backend/modules/profile/dto/getUserBuyOffer.query.ts
+++ b/src/backend/modules/profile/dto/getUserBuyOffer.query.ts
@@ -13,8 +13,8 @@ export class GetUserBuyOfferQuery extends Pagination {
   @IsOptional()
   readonly companyName?: string;
 
-  @Type(() => Number)
-  @IsInt()
+
+  @IsString()
   @IsOptional()
   readonly status?: OfferStatus;
 }

--- a/src/backend/modules/profile/dto/getUserBuyOffer.query.ts
+++ b/src/backend/modules/profile/dto/getUserBuyOffer.query.ts
@@ -2,6 +2,7 @@ import { Type } from "class-transformer";
 import { IsEnum, IsInt, IsOptional, IsString } from "class-validator";
 import { OrderByForUserBuyOffer } from "../enum/orderByForUserBuyOffer.enum";
 import { Pagination } from "../../../queries/pagination.query";
+import { OfferStatus } from "@prisma/client";
 
 export class GetUserBuyOfferQuery extends Pagination {
   @IsEnum(OrderByForUserBuyOffer)
@@ -15,5 +16,5 @@ export class GetUserBuyOfferQuery extends Pagination {
   @Type(() => Number)
   @IsInt()
   @IsOptional()
-  readonly status?: number;
+  readonly status?: OfferStatus;
 }

--- a/src/backend/modules/profile/dto/getUserSellOffer.query.ts
+++ b/src/backend/modules/profile/dto/getUserSellOffer.query.ts
@@ -13,8 +13,8 @@ export class GetUserSellOfferQuery extends Pagination {
   @IsOptional()
   readonly companyName?: string;
 
-  @Type(() => Number)
-  @IsInt()
+
+  @IsString()
   @IsOptional()
   readonly status?: OfferStatus;
 }

--- a/src/backend/modules/profile/dto/getUserSellOffer.query.ts
+++ b/src/backend/modules/profile/dto/getUserSellOffer.query.ts
@@ -2,6 +2,7 @@ import { Type } from "class-transformer";
 import { IsEnum, IsInt, IsOptional, IsString } from "class-validator";
 import { OrderByForUserSellOffer } from "../enum/orderByForUserSellOffer.enum";
 import { Pagination } from "../../../queries/pagination.query";
+import { OfferStatus } from "@prisma/client";
 
 export class GetUserSellOfferQuery extends Pagination {
   @IsEnum(OrderByForUserSellOffer)
@@ -15,5 +16,5 @@ export class GetUserSellOfferQuery extends Pagination {
   @Type(() => Number)
   @IsInt()
   @IsOptional()
-  readonly status?: number;
+  readonly status?: OfferStatus;
 }

--- a/src/backend/modules/profile/profile.service.ts
+++ b/src/backend/modules/profile/profile.service.ts
@@ -54,7 +54,7 @@ export class ProfileService {
                     unitSellPriceCents: true,
                   },
                   where: {
-                    status: 0
+                    status: "ACTIVE"
                   },
                 },
               },

--- a/src/backend/modules/transaction/transaction.service.ts
+++ b/src/backend/modules/transaction/transaction.service.ts
@@ -27,7 +27,7 @@ export class TransactionService {
   async getActiveBuyOffers() {
     return this.prisma.buyOffer.findMany({
       where: {
-        status: 0,
+        status: "ACTIVE",
       },
       select: {
         buyOfferId: true,
@@ -50,25 +50,25 @@ export class TransactionService {
   async checkOfferValidity() {
     await this.prisma.buyOffer.updateMany({
       where: {
-        status: 0,
+        status: "ACTIVE",
         created: {
           lte: new Date(Date.now() - 60 * 60 * 1000),
         },
       },
       data: {
-        status: 1,
+        status: "EXPIRED",
       },
     });
 
     await this.prisma.sellOffer.updateMany({
       where: {
-        status: 0,
+        status: "ACTIVE",
         created: {
           lte: new Date(Date.now() - 60 * 60 * 1000),
         },
       },
       data: {
-        status: 1,
+        status: "EXPIRED",
       },
     });
   }
@@ -95,7 +95,7 @@ export class TransactionService {
 
     const matchingSellOffers = await this.prisma.sellOffer.findMany({
       where: {
-        status: 0,
+        status: "ACTIVE",
         unitSellPriceCents: {
           lte: unitBuyPriceCents,
         },
@@ -175,7 +175,7 @@ export class TransactionService {
         buyOfferId: buyOfferId,
       },
       data: {
-        status: 2,
+        status: "NO_SUFFICIENT_FUNDS",
       },
     });
   }
@@ -247,11 +247,11 @@ export class TransactionService {
             quantity: {
               set: 0,
             },
-            status: 4,
+            status: "NO_USER_STOCK",
             Transaction: {
               create: {
                 buyOfferId: buyOffer.buyOfferId,
-                status: 5,
+                status: "TRANSACTION_REALIZED",
                 sellerId: sellOfferFull.userId,
                 buyerId: buyOffer.userId,
               },
@@ -293,11 +293,11 @@ export class TransactionService {
           quantity: {
             decrement: sellOfferTake,
           },
-          status: 0,
+          status: "ACTIVE",
           Transaction: {
             create: {
               buyOfferId: buyOffer.buyOfferId,
-              status: 5,
+              status: "TRANSACTION_REALIZED",
               sellerId: sellOffer.userId,
               buyerId: buyOffer.userId,
             },
@@ -334,7 +334,7 @@ export class TransactionService {
         buyOfferId: buyOffer.buyOfferId,
       },
       data: {
-        status: buyOfferQuantityLeft > 0 ? 0 : 4,
+        status: buyOfferQuantityLeft > 0 ? "ACTIVE" : "OFFER_REALIZED",
         quantity: {
           set: buyOfferQuantityLeft,
         },
@@ -383,7 +383,7 @@ export class TransactionService {
             companyId: buyOffer.companyId,
           },
         },
-        status: 0,
+        status: "ACTIVE",
       },
       take: 1,
       orderBy: {

--- a/src/backend/modules/transaction/transaction.service.ts
+++ b/src/backend/modules/transaction/transaction.service.ts
@@ -247,7 +247,7 @@ export class TransactionService {
             quantity: {
               set: 0,
             },
-            status: "NO_USER_STOCK",
+            status: "OFFER_REALIZED",
             Transaction: {
               create: {
                 buyOfferId: buyOffer.buyOfferId,


### PR DESCRIPTION
Changed "status" field on tables: BuyOffer, SellOffer and Transaction from integer that represents these statuses:

```
// 0 - Active offer
// 1 - Expired offer
// 2 - User has no sufficient funds
// 3 - User has no stock
// 4 - Offer realized
// 5 - Transaction realized
```
To enum:

```
enum OfferStatus {
  ACTIVE
  EXPIRED
  NO_SUFFICIENT_FUNDS
  NO_USER_STOCK
  OFFER_REALIZED
  TRANSACTION_REALIZED
}
```

- Migration 20221211221345_buy_sell_offer_enum makes these changes on DB.
- Seeding file was updated (defaults to ACTIVE on all new buy/sell offers).
- Back-end code was adjusted.
